### PR TITLE
Close out async done() if queue.length() is zero.

### DIFF
--- a/tasks/beep.js
+++ b/tasks/beep.js
@@ -41,5 +41,10 @@ module.exports = function(grunt) {
     } else {
       beep(many);
     }
+
+    if (queue.length() === 0) {
+      done();
+    }
+
   });
 };


### PR DESCRIPTION
I'm not 100% sure if this is due to recent changes in `grunt.util.async.queue`, but it looks as though `queue.drain()` doesn't call if the queue is never pushed to. So if you're using the error/warn options, and there are no errors, `done()` never fires, and your grunt task queue never moves beyond beep.

Doing a simple check for `queue.length()` fixes that, and works well for me. Let me know if you see any issues.

Thanks for a great task, perfect for creating "annoyance modes" for our local watches. :)
